### PR TITLE
Fix next/prev navigation

### DIFF
--- a/_api/00-apis.html
+++ b/_api/00-apis.html
@@ -1,6 +1,5 @@
 ---
 layout: guides
-collection: api
 title: APIs
 name: 00-apis
 hide: true

--- a/_api/00-apis.html
+++ b/_api/00-apis.html
@@ -3,7 +3,7 @@ layout: guides
 title: APIs
 name: 00-apis
 hide: true
-next: 01-omniscient-api-reference
+om_next: 01-omniscient-api-reference
 permalink: /api/
 ---
 

--- a/_api/00-apis.html
+++ b/_api/00-apis.html
@@ -23,11 +23,11 @@ of yet. You can see all projects on the <a href="https://github.com/omniscientjs
 <ol>
 {% for item in site.api %}
 {% if item.hide != true %}
-  {% assign pageID = @context.registers[:page]["id"] %}
-  {% assign itemID = item["name"]%}
+  {% assign pageID = @context.registers[:page].id %}
+  {% assign itemID = item.name %}
   {% assign className = pageID == itemID ? ' class="active"' : '' %}
     <li>
-      <a href="/{{item["collection"]}}/{{itemID}}"{{className}}>{{item["title"]}}</a>
+      <a href="/{{ item.collection }}/{{ itemID }}"{{ className }}>{{ item.title }}</a>
     </li>
 {% endif %}
 {% endfor %}

--- a/_api/01-omniscient-api-reference.md
+++ b/_api/01-omniscient-api-reference.md
@@ -2,8 +2,8 @@
 layout: guides
 title: Omniscient API Reference
 name: 01-omniscient-api-reference
-prev: 00-apis
-next: 02-immstruct-api-reference
+om_prev: ''
+om_next: 02-immstruct-api-reference
 ---
 
 
@@ -419,4 +419,4 @@ but adjusted to not accept objects to avoid collision with props.
 
 
 
-**Returns** `Boolean`, 
+**Returns** `Boolean`,

--- a/_api/01-omniscient-api-reference.md
+++ b/_api/01-omniscient-api-reference.md
@@ -1,6 +1,5 @@
 ---
 layout: guides
-collection: api
 title: Omniscient API Reference
 name: 01-omniscient-api-reference
 prev: 00-apis

--- a/_api/02-immstruct-api-reference.md
+++ b/_api/02-immstruct-api-reference.md
@@ -1,6 +1,5 @@
 ---
 layout: guides
-collection: api
 title: Immstruct API Reference
 prev: 01-omniscient-api-reference
 name: 02-immstruct-api-reference

--- a/_api/02-immstruct-api-reference.md
+++ b/_api/02-immstruct-api-reference.md
@@ -1,9 +1,9 @@
 ---
 layout: guides
 title: Immstruct API Reference
-prev: 01-omniscient-api-reference
 name: 02-immstruct-api-reference
-next: 03-omnipotent-api-reference
+om_prev: 01-omniscient-api-reference
+om_next: 03-omnipotent-api-reference
 ---
 
 *API Reference for `Immstruct v2.0.0`*

--- a/_api/03-omnipotent-api-reference.md
+++ b/_api/03-omnipotent-api-reference.md
@@ -1,6 +1,5 @@
 ---
 layout: guides
-collection: api
 title: Omnipotent API Reference
 name: 03-omnipotent-api-reference
 prev: 02-immstruct-api-reference

--- a/_api/03-omnipotent-api-reference.md
+++ b/_api/03-omnipotent-api-reference.md
@@ -2,7 +2,7 @@
 layout: guides
 title: Omnipotent API Reference
 name: 03-omnipotent-api-reference
-prev: 02-immstruct-api-reference
+om_prev: 02-immstruct-api-reference
 ---
 
 *API Reference for `Omnipotent v1.2.0`*

--- a/_guides/00-all-guides.html
+++ b/_guides/00-all-guides.html
@@ -1,6 +1,5 @@
 ---
 layout: guides
-collection: guides
 title: All Guides
 hide: true
 permalink: /guides/

--- a/_guides/00-all-guides.html
+++ b/_guides/00-all-guides.html
@@ -4,7 +4,7 @@ title: All Guides
 hide: true
 permalink: /guides/
 name: 00-all-guides
-next: 01-simpler-ui-reasoning-with-unidirectional
+om_next: 01-simpler-ui-reasoning-with-unidirectional
 ---
 
 <p>Here is a complete list of all the guides that exist in the Omniscient documentation. If you feel

--- a/_guides/00-all-guides.html
+++ b/_guides/00-all-guides.html
@@ -13,11 +13,11 @@ like there's something missing, please help us out by sending a pull request or 
 <ol>
 {% for item in site.guides %}
 {% if item.hide != true %}
-  {% assign pageID = @context.registers[:page]["id"] %}
-  {% assign itemID = item["name"]%}
+  {% assign pageID = @context.registers[:page].id %}
+  {% assign itemID = item.name %}
   {% assign className = pageID == itemID ? ' class="active"' : '' %}
     <li>
-      <a href="/{{item["collection"]}}/{{itemID}}"{{className}}>{{item["title"]}}</a>
+      <a href="/{{ item.collection }}/{{ itemID }}"{{ className }}>{{ item.title }}</a>
     </li>
 {% endif %}
 {% endfor %}

--- a/_guides/01-simpler-ui-reasoning-with-unidirectional.md
+++ b/_guides/01-simpler-ui-reasoning-with-unidirectional.md
@@ -2,8 +2,8 @@
 layout: guides
 title: Simpler UI Reasoning with Unidirectional Dataflow and Immutable Data
 name: 01-simpler-ui-reasoning-with-unidirectional
-prev: 00-all-guides
-next: 02-immutable-data-cursors-and-omniscient
+om_prev: ''
+om_next: 02-immutable-data-cursors-and-omniscient
 date: October 27, 2014
 ---
 

--- a/_guides/01-simpler-ui-reasoning-with-unidirectional.md
+++ b/_guides/01-simpler-ui-reasoning-with-unidirectional.md
@@ -1,6 +1,5 @@
 ---
 layout: guides
-collection: guides
 title: Simpler UI Reasoning with Unidirectional Dataflow and Immutable Data
 name: 01-simpler-ui-reasoning-with-unidirectional
 prev: 00-all-guides

--- a/_guides/02-immutable-data-cursors-and-omniscient.md
+++ b/_guides/02-immutable-data-cursors-and-omniscient.md
@@ -2,7 +2,7 @@
 layout: guides
 title: Immutable data, Cursors and Omniscient
 name: 02-immutable-data-cursors-and-omniscient
-prev: 01-simpler-ui-reasoning-with-unidirectional
+om_prev: 01-simpler-ui-reasoning-with-unidirectional
 date: March 1, 2015
 ---
 

--- a/_guides/02-immutable-data-cursors-and-omniscient.md
+++ b/_guides/02-immutable-data-cursors-and-omniscient.md
@@ -1,6 +1,5 @@
 ---
 layout: guides
-collection: guides
 title: Immutable data, Cursors and Omniscient
 name: 02-immutable-data-cursors-and-omniscient
 prev: 01-simpler-ui-reasoning-with-unidirectional

--- a/_layouts/guides.html
+++ b/_layouts/guides.html
@@ -18,10 +18,11 @@ layout: default
 </div>
 
 <div class="docs-prevnext">
-  {% if page.prev %}
-    <a class="docs-prev" href="/{{ page.collection }}/{{ page.prev }}">&larr; Prev</a>
+  {% if page.om_prev %}
+  <a class="docs-prev" href="/{{ page.collection }}/{{ page.om_prev }}">&larr; Prev</a>
   {% endif %}
-  {% if page.next %}
-    <a class="docs-next" href="/{{ page.collection }}/{{ page.next }}">Next &rarr;</a>
+
+  {% if page.om_next %}
+  <a class="docs-next" href="/{{ page.collection }}/{{ page.om_next }}">Next &rarr;</a>
   {% endif %}
 </div>

--- a/_layouts/guides.html
+++ b/_layouts/guides.html
@@ -6,8 +6,9 @@ layout: default
   {{ page.title }}
   <a class="edit-page-link" href="https://github.com/omniscientjs/omniscientjs.github.io/blob/master/{{ page.relative_path }}" target="_blank">Edit on GitHub</a>
 </h1>
-{% if page.date %}
-  <p><strong>Originally posted <time>{{page.date}}</time></strong></p>
+
+{% if page.hide != true %}
+  <p><strong>Originally posted <time>{{ page.date }}</time></strong></p>
 {% endif %}
 
 <div class="subHeader">{{ page.description }}</div>

--- a/_layouts/playground.html
+++ b/_layouts/playground.html
@@ -8,7 +8,7 @@
     <a class="anchor-link" id="content"></a>
     <main class="mainContent playground" >
       {% assign codeContent = content | strip_newlines %}
-      <div class="editor" data-is-large=true><textarea>{% if (codeContent == "") %}{% include _playground-default.html %}{% else %}{{ content }}{% endif %}</textarea></div>
+      <div class="editor" data-is-large=true><textarea>{% if codeContent == "" %}{% include _playground-default.html %}{% else %}{{ content }}{% endif %}</textarea></div>
 
       <div class="padded-info">
         <h3>Help</h3>

--- a/_layouts/workshop.html
+++ b/_layouts/workshop.html
@@ -23,7 +23,7 @@
       </div>
 
       {% assign codeContent = content | strip_newlines %}
-      <div class="editor" data-is-large=true><textarea>{% if (codeContent == "") %}{% include _playground-default.html %}{% else %}{{ content }}{% endif %}</textarea></div>
+      <div class="editor" data-is-large=true><textarea>{% if codeContent == "" %}{% include _playground-default.html %}{% else %}{{ content }}{% endif %}</textarea></div>
 
       <h2>Tasks</h2>
       <ol>

--- a/_playground/00-all-playgrounds.html
+++ b/_playground/00-all-playgrounds.html
@@ -1,6 +1,5 @@
 ---
 layout: playground
-collection: playground
 title: Simple Todo List
 permalink: /playground/
 ---

--- a/_playground/01-inline-edit.html
+++ b/_playground/01-inline-edit.html
@@ -3,7 +3,6 @@ layout: playground
 collection: playground
 title: List with inline edit
 name: 01-inline-edit
-prev: 00-all-playgrounds
 ---
 
 // Shortcut for DOM-creation

--- a/_playground/02-search.html
+++ b/_playground/02-search.html
@@ -3,7 +3,6 @@ layout: playground
 collection: playground
 title: Search list
 name: 02-search
-prev: 01-inline-edit
 ---
 
 var d = React.DOM;

--- a/_playground/03-tests.html
+++ b/_playground/03-tests.html
@@ -3,7 +3,6 @@ layout: playground
 collection: playground
 title: Tests
 name: 03-tests
-prev: 02-search
 ---
 
 describe('mocha inside playground', function () {

--- a/_playground/04-single-react-component.html
+++ b/_playground/04-single-react-component.html
@@ -3,7 +3,6 @@ layout: playground
 collection: playground
 title: Single react component
 name: 04-single-react-component
-prev: 03-tests
 ---
 
 const Comp = React.createClass({

--- a/_tutorials/00-all-tutorials.html
+++ b/_tutorials/00-all-tutorials.html
@@ -13,11 +13,11 @@ like there's something missing, please help us out by sending a pull request or 
 <ol>
 {% for item in site.tutorials %}
 {% if item.hide != true %}
-  {% assign pageID = @context.registers[:page]["id"] %}
-  {% assign itemID = item["name"]%}
+  {% assign pageID = @context.registers[:page].id %}
+  {% assign itemID = item.name %}
   {% assign className = pageID == itemID ? ' class="active"' : '' %}
     <li>
-      <a href="/{{item["collection"]}}/{{itemID}}"{{className}}>{{item["title"]}}</a>
+      <a href="/{{ item.collection }}/{{ itemID }}"{{ className }}>{{ item.title }}</a>
     </li>
 {% endif %}
 {% endfor %}

--- a/_tutorials/00-all-tutorials.html
+++ b/_tutorials/00-all-tutorials.html
@@ -4,7 +4,7 @@ title: All Tutorials
 hide: true
 permalink: /tutorials/
 name: 00-all-tutorials
-next: 01-editing-basic-tutorial-creating-list-with-live-filtering
+om_next: 01-editing-basic-tutorial-creating-list-with-live-filtering
 ---
 
 <p>Here is a complete list of all the tutorials that exist in the Omniscient documentation. If you feel

--- a/_tutorials/00-all-tutorials.html
+++ b/_tutorials/00-all-tutorials.html
@@ -1,6 +1,5 @@
 ---
 layout: guides
-collection: tutorials
 title: All Tutorials
 hide: true
 permalink: /tutorials/

--- a/_tutorials/01-editing-basic-tutorial-creating-list-with-live-filtering.md
+++ b/_tutorials/01-editing-basic-tutorial-creating-list-with-live-filtering.md
@@ -3,8 +3,8 @@ layout: guides
 collection: tutorials
 title: Editing Basic Tutorial Creating List with Live Filtering
 name: 01-editing-basic-tutorial-creating-list-with-live-filtering
-prev: 00-all-tutorials
-next: 02-editing-basic-tutorial-creating-list-with-live-filtering-jsx-edition
+om_prev: ''
+om_next: 02-editing-basic-tutorial-creating-list-with-live-filtering-jsx-edition
 
 ---
 

--- a/_tutorials/02-editing-basic-tutorial-creating-list-with-live-filtering-jsx-edition.md
+++ b/_tutorials/02-editing-basic-tutorial-creating-list-with-live-filtering-jsx-edition.md
@@ -3,7 +3,7 @@ layout: guides
 collection: tutorials
 title: Editing Basic Tutorial Creating List with Live Filtering - JSX Edition
 name: 02-editing-basic-tutorial-creating-list-with-live-filtering-jsx-edition
-prev: 01-editing-basic-tutorial-creating-list-with-live-filtering
+om_prev: 01-editing-basic-tutorial-creating-list-with-live-filtering
 ---
 
 **Disclaimer: This tutorial is currently for Omniscient <code>v2.0.0</code> and is in the process of being updated to match the new syntax of Immutable.js 3.0.0 and Omniscient 3.0.0. See the [changelog](http://omniscientjs.github.io/changelog/)**


### PR DESCRIPTION
GitHub pages is powered by newer Jekyll which has overridden the original front matter in the current omniscientjs.github.com - this broke the internal page navigation in guides/apis/tutorials 

This fix only adds a prefix to the next/prev variable.